### PR TITLE
Add graph module tests and fix CI requirements

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -r lms_log_analyzer/requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+from lms_log_analyzer.src.graph_builder import GraphBuilder
+from lms_log_analyzer.src.graph_retrieval_tool import GraphRetrievalTool
+
+class TestGraphModules(TestCase):
+    def test_builder_methods_noop_without_graph(self):
+        builder = GraphBuilder(uri="bolt://invalid:7687")
+        builder.graph = None  # ensure no connection
+        # Should not raise when graph is unavailable
+        builder.create_entities([{"id": "e1", "label": "IP"}])
+        builder.create_relations([
+            {"start_id": "e1", "end_id": "e2", "type": "RELATED"}
+        ])
+
+    def test_retrieval_empty_without_graph(self):
+        builder = GraphBuilder(uri="bolt://invalid:7687")
+        builder.graph = None
+        tool = GraphRetrievalTool(builder)
+        result = tool.retrieve_for_line("Failed login from 1.1.1.1 user=root")
+        self.assertEqual(result, {"nodes": [], "relationships": []})


### PR DESCRIPTION
## Summary
- cover GraphBuilder and GraphRetrievalTool with new unit tests
- install project requirements from correct path in GitHub Actions workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487793edc08320a5d74afb551e2adb